### PR TITLE
fix: don't remove extension in library imports

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -3,9 +3,9 @@ jest.autoMockOff()
 const babel = require('babel-core')
 const plugin = require('../src/index')
 
-function transform (code) {
+function transform (code, options) {
   return babel.transform(code, {
-    plugins: [plugin]
+    plugins: [plugin].concat(options && [options] || [])
   }).code
 }
 
@@ -27,6 +27,13 @@ describe('trim-import-extension', () => {
   it('it should work with jsx', () => {
     const source = 'import Lib from "./lib.jsx";'
     const expected = 'import Lib from "./lib";'
+
+    expect(transform(source)).toBe(expected)
+  })
+
+  it('it should not remove .js extension from library submodules', () => {
+    const source = 'import React from "react-dom/submodule.js";'
+    const expected = 'import React from "react-dom/submodule.js";'
 
     expect(transform(source)).toBe(expected)
   })

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,11 @@ module.exports = function () {
           return
         }
 
+        if (!source.value.startsWith('.')) {
+          // Don't remove extension from library imports
+          return
+        }
+
         source.value = source.value.replace(regExp, '')
       }
     }


### PR DESCRIPTION
Avoid removing file extensions from library submodules, as they they may expose file with extensions.

For example, imagine that library `@some/library` exposes a module called `module.js`, so you would import it as:
```ts
import "@some/library/module.js";
```

Without this MR it would get converted to an incorrect import that cannot be resolved:
```ts
import "@some/library/module";
```